### PR TITLE
Bug 1204806 - Draw cursor while virtual mouse connected to TV

### DIFF
--- a/b2g/components/RemoteControlService.jsm
+++ b/b2g/components/RemoteControlService.jsm
@@ -236,7 +236,13 @@ this.RemoteControlService = {
       case "control-mode-changed":
         // Use mozContentEvent to receive control mode of current app from System App
         // remote_command.js use "getIsCursorMode" to determine what kind event should dispatch to app
-        this._isCursorMode = detail.detail.cursor;
+        // Add null check when system app initialization, cursor is null
+        let isCursorMode = (detail.detail.cursor === null)?false:detail.detail.cursor;
+        if (isCursorMode !== this._isCursorMode) {
+          this._isCursorMode = isCursorMode;
+          // Update mouse cursor when control mode changed
+          this.updateMouseCursor();
+        }
         break;
       case "remote-control-pin-dismissed":
         this.clearPIN();
@@ -270,6 +276,9 @@ this.RemoteControlService = {
       var conn = new Connection(input, output, this, connectionId);
       let handler = new EventHandler(conn);
 
+      // Update mouse cursor when establish a new connection
+      this.updateMouseCursor();
+
       input.asyncWait(conn, 0, 0, Services.tm.mainThread);
     } catch (e) {
       DEBUG && debug("Error in initial connection: " + e);
@@ -288,6 +297,21 @@ this.RemoteControlService = {
     this._connections.forEach(function(aConnection){
       aConnection.close();
     });
+  },
+
+  updateMouseCursor: function() {
+    let window = Services.wm.getMostRecentWindow("navigator:browser");
+    let utils = window.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIDOMWindowUtils);
+    let x = isNaN(parseInt(this._getSharedState("x"))) ? 0 : parseInt(this._getSharedState("x"));
+    let y = isNaN(parseInt(this._getSharedState("y"))) ? 0 : parseInt(this._getSharedState("y"));
+
+    if (this._isCursorMode && this._connections.size > 0) {
+      // Enable mouse cursor if it's in cursor mode and there is user connected.
+      utils.sendMouseEvent("MozEnableDrawCursor", x, y, 0, 0, 0);
+    } else {
+      // Disable mouse cursor
+      utils.sendMouseEvent("MozDisableDrawCursor", x, y, 0, 0, 0);
+    }
   },
 
   // PRIVATE FUNCTIONS
@@ -478,6 +502,8 @@ Connection.prototype = {
     this._closed = true;
 
     this.server._connectionClosed(this.connectionId);
+    // Update mouse cursor when connection closed
+    this.server.updateMouseCursor();
   },
 
   sendMsg: function(aMessage) {

--- a/dom/base/nsContentUtils.cpp
+++ b/dom/base/nsContentUtils.cpp
@@ -7760,6 +7760,13 @@ nsContentUtils::SendMouseEvent(nsCOMPtr<nsIPresShell> aPresShell,
     msg = eMouseUp;
   } else if (aType.EqualsLiteral("mousemove")) {
     msg = eMouseMove;
+#ifdef MOZ_WIDGET_GONK
+    // If need to draw mouse cursor, set point then force composition
+    if(widget->GetDrawVirtualMouse()) {
+      ScreenIntPoint point(floor(aX+0.5), floor(aY+0.5));
+      widget->SetMouseCursorPosition(point);
+    }
+#endif
   } else if (aType.EqualsLiteral("mouseover")) {
     msg = eMouseEnterIntoWidget;
   } else if (aType.EqualsLiteral("mouseout")) {
@@ -7771,7 +7778,15 @@ nsContentUtils::SendMouseEvent(nsCOMPtr<nsIPresShell> aPresShell,
     contextMenuKey = (aButton == 0);
   } else if (aType.EqualsLiteral("MozMouseHittest")) {
     msg = eMouseHitTest;
-  } else {
+  }
+#ifdef MOZ_WIDGET_GONK
+  else if (aType.EqualsLiteral("MozEnableDrawCursor")) {
+    widget->SetDrawVirtualMouse(true);
+  } else if (aType.EqualsLiteral("MozDisableDrawCursor")) {
+    widget->SetDrawVirtualMouse(false);
+  }
+#endif
+  else {
     return NS_ERROR_FAILURE;
   }
 

--- a/widget/gonk/nsWindow.cpp
+++ b/widget/gonk/nsWindow.cpp
@@ -134,6 +134,21 @@ nsWindow::ConfigureAPZControllerThread()
     APZThreadUtils::SetControllerThread(CompositorBridgeParent::CompositorLoop());
 }
 
+void
+nsWindow::SetMouseCursorPosition(const ScreenIntPoint& aScreenIntPoint)
+{
+    // The only implementation of nsIWidget::SetMouseCursorPosition in nsWindow
+    // is for remote control.
+    if (gFocusedWindow) {
+        // NB: this is a racy use of gFocusedWindow.  We assume that
+        // our one and only top widget is already in a stable state by
+        // the time we start receiving mousemove events.
+        gFocusedWindow->SetScreenIntPoint(aScreenIntPoint);
+        gFocusedWindow->mCompositorBridgeParent->InvalidateOnCompositorThread();
+        gFocusedWindow->mCompositorBridgeParent->ScheduleRenderOnCompositorThread();
+    }
+}
+
 /*static*/ nsEventStatus
 nsWindow::DispatchKeyInput(WidgetKeyboardEvent& aEvent)
 {

--- a/widget/gonk/nsWindow.h
+++ b/widget/gonk/nsWindow.h
@@ -136,6 +136,9 @@ public:
 
     nsScreenGonk* GetScreen();
 
+    // Call this function after remote control use nsContentUtils::SendMouseEvent
+    virtual void SetMouseCursorPosition(const ScreenIntPoint& aScreenIntPoint) override;
+
 protected:
     nsWindow* mParent;
     bool mVisible;

--- a/widget/nsIWidget.h
+++ b/widget/nsIWidget.h
@@ -2087,8 +2087,21 @@ public:
     virtual void SetDrawMouse(bool aDrawMouse)
     { mDrawMouse = aDrawMouse; }
 
+    virtual void SetDrawVirtualMouse(bool aDrawVirtualMouse)
+    { mDrawVirtualMouse = aDrawVirtualMouse; }
+
     virtual bool GetDrawMouse()
-    { return mDrawMouse; }
+    { return mDrawMouse || mDrawVirtualMouse; }
+
+    virtual bool GetDrawVirtualMouse()
+    { return mDrawVirtualMouse; }
+
+    /**
+     * For remote control draw mouse cursor in nsContentUtils.
+     * widget/gonk/nsWindow.cpp has real implementation.
+     * Otherwise, use empty implementation.
+     */
+    virtual void SetMouseCursorPosition(const ScreenIntPoint& aScreenIntPoint) { };
 
 protected:
     /**
@@ -2116,6 +2129,7 @@ protected:
     // over this widget.
     ScreenIntPoint mScreenPoint;
     bool mDrawMouse;
+    bool mDrawVirtualMouse;
 };
 
 NS_DEFINE_STATIC_IID_ACCESSOR(nsIWidget, NS_IWIDGET_IID)


### PR DESCRIPTION
This patch implements:
1. New mouse event type in nsContentUtils::SendMouseEvent for enable/disable
   draw mouse cursor
2. New API and empty implementation of nsIWidget::ForceComposition
   for nsContentUtils to draw mouse cursor after mousemove event
3. Real implementation of nsWindow::ForceComposition to invalidate and
   schedule render on compositor thread
4. Enable/disable draw mouse cursor while client connects and Gaia is in
   cursor mode
