### PR TITLE
Bug 1267129 - Fix ReferenceError: XPCOMUtils

### DIFF
--- a/toolkit/components/extensions/ext-backgroundPage.js
+++ b/toolkit/components/extensions/ext-backgroundPage.js
@@ -3,6 +3,7 @@
 var {interfaces: Ci, utils: Cu} = Components;
 
 Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyModuleGetter(this, "AddonManager",
                                   "resource://gre/modules/AddonManager.jsm");
 


### PR DESCRIPTION
Fix "ReferenceError: XPCOMUtils is no defined backgroundPage.js" on nexus 5
