### PR TITLE
Bug 1283006 - Add network status change observer

### DIFF
--- a/b2g/components/RemoteControlService.jsm
+++ b/b2g/components/RemoteControlService.jsm
@@ -140,7 +140,7 @@ this.RemoteControlService = {
     Services.obs.removeObserver(this, "xpcom-shutdown");
 
     if (this._mDNSRegistrationHandle) {
-      this._mDNSRegistrationHandle.Cancel(Cr.NS_OK);
+      this._mDNSRegistrationHandle.cancel(Cr.NS_OK);
       this._mDNSRegistrationHandle = null;
     }
 


### PR DESCRIPTION
Turn off wifi network will make tls socket server stop listening.
Add network status change observer to stop when network down and
start when network up.
